### PR TITLE
[bigdft-atlab] fix futile headers

### DIFF
--- a/var/spack/repos/builtin/packages/bigdft-atlab/package.py
+++ b/var/spack/repos/builtin/packages/bigdft-atlab/package.py
@@ -49,7 +49,7 @@ class BigdftAtlab(AutotoolsPackage):
         args = [
             "FCFLAGS=%s" % " ".join(fcflags),
             "--with-futile-libs=%s" % spec["bigdft-futile"].libs.ld_flags,
-            "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags,
+            "--with-futile-incs=%s" % spec["bigdft-futile"].headers.include_flags+"/futile",
             "--with-moduledir=%s" % prefix.include,
             "--prefix=%s" % prefix,
             "--without-etsf-io",


### PR DESCRIPTION
bidft-atlab fails to compile ( see here https://github.com/spack/spack/issues/34351#issuecomment-1378623576) due to an incorrect directory being used in the configure flag `--with-futile-incs=`. This PR fixes the path.